### PR TITLE
fixed bug: loader fails when this.options.glsl is undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ module.exports = function(source) {
 
 	this.finalString = source
 
-	if(this.options.glsl.chunkPath){
+	if(this.options.glsl && this.options.glsl.chunkPath){
 		chunkPath =  this.options.glsl.chunkPath
 	}
 


### PR DESCRIPTION
if user doesn't have any chunk, user should not need to specify glsl: {} in webpack config.
