### PR TITLE
Allow dots and dashes in chunk names

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ module.exports = function(source) {
 	this.queue = 0
 	this.isDone = false
 
-	r = /\$(\w+)/gi
+	r = /\$[\w-.]+/gi
 
 	chunks = {}
 	match = source.match( r )


### PR DESCRIPTION
This allows `$common.vert` or `$common-vx` to be chunk names for those who may follow that file naming convention. Previously, anything beyond the dot or dash would be ignored and "common.glsl" would be attempted to be loaded.
