### PR TITLE
Fix options for Webpack 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+.DS_Store
+node_modules/
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Editor directories and files
+.idea
+*.suo
+*.ntvs*
+*.njsproj
+*.sln

--- a/README.md
+++ b/README.md
@@ -12,12 +12,17 @@ npm install shader-loader --save-dev
 Config webpack:
 ``` javascript
 module: {
-	loaders: [
-		{ test: /\.(glsl|vs|fs)$/, loader: 'shader' },
-	],
-},
-glsl: {
-	chunkPath: path(__dirname,"/glsl/chunks")
+	rules: [
+      {
+        test: /\.(glsl|vs|fs)$/,
+        loader: 'shader-loader',
+        options: {
+          glsl: {
+            chunkPath: resolve("/glsl/chunks")
+          }
+        }
+      }
+	]
 }
 ```
 

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 var path = require('path')
 var fs = require('fs')
+var loaderUtils = require('loader-utils')
 
 var chunks = {}
 var chunkPath = ""
@@ -13,8 +14,10 @@ module.exports = function(source) {
 		uid.queue = 0
 		uid.done = false
 
-	if(this.options.glsl && this.options.glsl.chunkPath){
-		chunkPath =  this.options.glsl.chunkPath
+	var options = loaderUtils.getOptions(this) || {}
+
+	if(options.glsl && options.glsl.chunkPath){
+		chunkPath =  options.glsl.chunkPath
 	}
 
 	var r = /\$[\w-.]+/gi

--- a/package.json
+++ b/package.json
@@ -1,26 +1,29 @@
 {
   "name": "shader-loader",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "glsl loader for webpack working with chunks (inspired by ShaderLoader from cabbibo)",
   "main": "index.js",
   "scripts": {
-	"test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {
-	"type": "git",
-	"url": "https://github.com/Makio64/shader-loader"
+    "type": "git",
+    "url": "https://github.com/Makio64/shader-loader"
   },
   "keywords": [
-	"glsl",
-	"webpack",
-	"loader",
-	"shader",
-	"chunks"
+    "glsl",
+    "webpack",
+    "loader",
+    "shader",
+    "chunks"
   ],
   "author": "David Ronai @Makio64",
   "license": "MIT",
   "bugs": {
-	"url": "https://github.com/Makio64/shader-loader/issues"
+    "url": "https://github.com/Makio64/shader-loader/issues"
   },
-  "homepage": "https://github.com/Makio64/shader-loader"
+  "homepage": "https://github.com/Makio64/shader-loader",
+  "dependencies": {
+    "loader-utils": "^1.1.0"
+  }
 }


### PR DESCRIPTION
The method to pass the options wasn't allow with Webpack 2. 
I used the new one.