### PR TITLE
Add module for use of resolve

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ npm install shader-loader --save-dev
 
 Config webpack:
 ``` javascript
+const path = require("path");
+
 module: {
 	rules: [
       {
@@ -18,7 +20,7 @@ module: {
         loader: 'shader-loader',
         options: {
           glsl: {
-            chunkPath: resolve("/glsl/chunks")
+            chunkPath: path.resolve(__dirname, "glsl/chunks")
           }
         }
       }


### PR DESCRIPTION
Firstly let me say thanks for your work on this, it helps a ton!!

---

I made the use of `resolve` a little more explicit by including the `path` module and changing the function call. I also added the `__dirname` to the path string as I believe this will help new users of nodejs and webpack by letting them know where their files should be placed relative to the config file.

It should also help with the people who want to just copy/paste the config since they may encounter an error if they don't require said path module before using the `resolve` function.
